### PR TITLE
Update Strapi peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "@strapi/strapi": "4.0.7"
+    "@strapi/strapi": "^4.0.0"
   },
   "author": {
     "name": "exFabrica.io",


### PR DESCRIPTION
Hello! Your previous dependency meant that your plugin only works with Strapi v4.0.7 _specifically_.

Instead what you likely want is "this version and above, up until the next major (breaking) version". That's what the ^ symbol means.

I also took the liberty of setting 4.0.0 instead of 4.0.7, as there should be no change between these versions that affects your plugin.